### PR TITLE
Adding proper timezone support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include Authentication
   include Pundit::Authorization
 
+  around_action :switch_timezone
+
   before_action :set_paper_trail_whodunnit
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -11,5 +13,19 @@ class ApplicationController < ActionController::Base
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
     redirect_to(request.referrer || root_path)
+  end
+
+  def switch_timezone(&action)
+    Time.use_zone(timezone_from_cookies, &action)
+  rescue TZInfo::UnknownTimezone, TZInfo::InvalidTimezoneIdentifier
+    Time.zone
+  end
+
+  def timezone_from_cookies
+    if cookies[:timezone].nil?
+      return "Etc/UTC"
+    else
+      return cookies[:timezone]
+    end
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("order-questions", OrderQuestionsController)
 import ResetFormController from "./reset_form_controller"
 application.register("reset-form", ResetFormController)
 
+import TimeZoneController from "./time_zone_controller"
+application.register("time-zone", TimeZoneController)
+
 import ToggleController from "./toggle_controller"
 application.register("toggle", ToggleController)
 

--- a/app/javascript/controllers/time_zone_controller.js
+++ b/app/javascript/controllers/time_zone_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="time-zone"
+export default class extends Controller {
+  static values = {
+    domain: { type: String, default: "localhost" },
+  };
+
+  connect() {
+    console.debug("TIMEZONE!");
+    // Set the user's timezone based on their browser timezone configuration
+    // and save it to a cookie (which expires 1 day from its creation time)
+    // If the cookie is not expired, we read the timezone from the cookie instead.
+    if (this.readTimezoneCookie() === undefined) {
+      _ = this.saveTimezoneCookie();
+    }
+  }
+
+  saveTimezoneCookie() {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let expires = new Date();
+    expires.setTime(expires.getTime() + 60 * 60 * 24 * 1000);
+    expires = expires.toGMTString();
+    document.cookie = `timezone=${timezone};expires=${expires};path=/`;
+  }
+
+  readTimezoneCookie() {
+    const name = "timezone=";
+    const cDecoded = decodeURIComponent(document.cookie); //to be careful
+    const cArr = cDecoded.split("; ");
+    let res;
+    cArr.forEach((val) => {
+      if (val.indexOf(name) === 0) res = val.substring(name.length);
+    });
+    return res;
+  }
+
+  offsetToUTC() {
+    const date = new Date();
+    return date.getTimezoneOffset();
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <% end %>
     <%= favicon_link_tag asset_path('favicon.png') %>
   </head>
-  <body class="antialiased">
+  <body class="antialiased" data-controller="time-zone">
     <div class="flex flex-col min-h-screen bg-white dark:bg-gray-900">
       <header class="sticky top-0 z-40 flex-none mx-auto w-full bg-white border-b border-gray-200 dark:border-gray-600 dark:bg-gray-800">
         <%# render "shared/banner" %>

--- a/db/migrate/20230320192611_add_timezone_to_user.rb
+++ b/db/migrate/20230320192611_add_timezone_to_user.rb
@@ -1,0 +1,6 @@
+class AddTimezoneToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :time_zone, :string
+    add_index  :users, :time_zone
+  end
+end


### PR DESCRIPTION
* Add a stimulus controller to retrieve the user's timezone from the browser
* Save the user's timezone in a cookie accessible throughout the domain
* Add action_around filter in the ApplicationController to assign the timezone in the cookie to the app. In case the timezone is not recognized we default to Time.zone

Future work: user profile is now given a time_zone field (string) to store user's preferred timezone. For the moment this feature is not yet implemented and we rely on the cookie to save the timezone.